### PR TITLE
adding remove line breaks feature

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4,6 +4,8 @@ let path = require('path');
 
 let gShortcut;
 
+let isRemoveLineBreaks = false;
+
 const Store = require('electron-store');
 const store = new Store();
 
@@ -48,6 +50,14 @@ app.on('ready', function() {
                 //                        hotkeySettingsWindow.webContents.openDevTools();
 
                 hotkeySettingsWindow.loadFile(path.join(__static, 'hotkey.html'))
+            }
+        }, {
+            label: "Remove Line Breaks",
+            type: "checkbox",
+            checked: false,
+            click: (item) => {
+                isRemoveLineBreaks = item.checked;
+                win.webContents.send('translateClipboard', item.checked);
             }
         }, {
             label: "Quit",
@@ -134,7 +144,7 @@ ipcMain.on('set-hotkey', (event, arg) => {
 
 function registerShortcut(newShortcut, oldShortcut) {
     let shortcut = globalShortcut.register(newShortcut, () => {
-        win.webContents.send('translateClipboard');
+        win.webContents.send('translateClipboard', isRemoveLineBreaks);
         win.show()
     });
 

--- a/static/preload.js
+++ b/static/preload.js
@@ -14,9 +14,8 @@ const inputValue = (dom, st) => {
     dom.dispatchEvent(evt);
 }
 
-ipcRenderer.on('translateClipboard', function() {
-    inputValue(document.querySelector('d-textarea'), clipboard.readText());
-
+ipcRenderer.on('translateClipboard', (event, isChecked) => {
+    inputValue(document.querySelector('d-textarea'), (isChecked) ? clipboard.readText().split("\n").join(" ") : clipboard.readText());
 });
 
 window.addEventListener('load', (event) => {


### PR DESCRIPTION
Sometimes we need to remove line breaks from text for better translations.

[+] Remove Line Breaks (checkbox)

for example,

from this:
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ut feugiat sem. Sed nec ipsum lectus. 
Proin consectetur urna dignissim velit mattis interdum. Curabitur sed elit sed mauris finibus luctus. 
Quisque eu enim aliquet, pretium augue vitae, egestas nisl. Suspendisse potenti. Duis dapibus vehicula arcu sit amet molestie. Mauris sodales a augue at venenatis.

to this:
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ut feugiat sem. Sed nec ipsum lectus. Proin consectetur urna dignissim velit mattis interdum. Curabitur sed elit sed mauris finibus luctus. Quisque eu enim aliquet, pretium augue vitae, egestas nisl. Suspendisse potenti. Duis dapibus vehicula arcu sit amet molestie. Mauris sodales a augue at venenatis.